### PR TITLE
Changes based on experience with VARA-FM testing

### DIFF
--- a/vara/conn.go
+++ b/vara/conn.go
@@ -4,7 +4,7 @@ import (
 	"net"
 )
 
-// Wrapper for the data port connection we hand to clients.
+// Wrapper for the data port connection we hand to clients. Implements net.Conn.
 type varaDataConn struct {
 	// the underlying TCP conn we're wrapping (type embedding)
 	net.TCPConn
@@ -14,7 +14,23 @@ type varaDataConn struct {
 
 // Close closes the connection.
 // Any blocked Read or Write operations will be unblocked and return errors.
+//
+// "Overrides" net.Conn.Close.
 func (v *varaDataConn) Close() error {
 	// If client wants to close the data stream, close down RF and TCP as well
 	return v.modem.Close()
+}
+
+// LocalAddr returns the local network address.
+//
+// "Overrides" net.Conn.LocalAddr.
+func (v *varaDataConn) LocalAddr() net.Addr {
+	return Addr{v.modem.myCall}
+}
+
+// RemoteAddr returns the remote network address.
+//
+// "Overrides" net.Conn.RemoteAddr.
+func (v *varaDataConn) RemoteAddr() net.Addr {
+	return Addr{v.modem.toCall}
 }

--- a/vara/transport.go
+++ b/vara/transport.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/la5nta/wl2k-go/transport"
 )
@@ -31,6 +30,11 @@ func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
 		}
 	}
 
+	// Set MYCALL
+	if err := m.writeCmd(fmt.Sprintf("MYCALL %s", m.myCall)); err != nil {
+		return nil, err
+	}
+
 	// Set bandwidth from the URL
 	if err := m.setBandwidth(url); err != nil {
 		return nil, err
@@ -53,19 +57,14 @@ func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
 }
 
 func (m *Modem) setBandwidth(url *transport.URL) error {
-	var bandwidth int
 	bw := url.Params.Get("bw")
-	if bw != "" {
-		var err error
-		bandwidth, err = strconv.Atoi(bw)
-		if err != nil {
-			return fmt.Errorf("parsing bw: %w", err)
-		}
+	if bw == "" {
+		return nil
 	}
-	if bandwidth != 500 && bandwidth != 2750 {
-		bandwidth = 2300
+	if bw != "500" && bw != "2300" && bw != "2750" {
+		return errors.New(fmt.Sprintf("bandwidth %s not supported", bw))
 	}
-	return m.writeCmd(fmt.Sprintf("BW%d", bandwidth))
+	return m.writeCmd(fmt.Sprintf("BW%s", bw))
 }
 
 // Busy returns true if the channel is not clear.
@@ -73,8 +72,8 @@ func (m *Modem) Busy() bool {
 	return m.busy
 }
 
-// SetPTT sets the PTTController (probably hooked to a transceiver) that should be controlled by the
-// modem.
+// SetPTT injects the PTTController (probably hooked to a transceiver) that should be controlled by
+// the modem.
 //
 // If nil, the PTT request from the TNC is ignored. VOX may still work.
 func (m *Modem) SetPTT(ptt transport.PTTController) {


### PR DESCRIPTION
* `varaDataConn.LocalAddr` and `RemoteAddr` should be callsigns, not data TCP port
* Set `MYCALL`
* Don't set bandwidth 2300 for VARA-FM
* Refactor out `Modem.handleCmd` for readability
* Prefix VARA debug logs