### PR TITLE
Ignore the REGISTERED command from the modem

### DIFF
--- a/vara/vara.go
+++ b/vara/vara.go
@@ -206,6 +206,10 @@ func (m *Modem) handleCmd(c string) bool {
 			// nothing to do
 			break
 		}
+		if strings.HasPrefix(c, "REGISTERED") {
+			// nothing to do
+			break
+		}
 		log.Printf("got a vara command I wasn't expecting: %v", c)
 	}
 	return true


### PR DESCRIPTION
Based on beta feedback, e.g. [this](https://groups.google.com/g/pat-users/c/GpBuLZEGAAk/m/6oN1sawHBgAJ) and [this](https://groups.google.com/g/pat-users/c/F8qXAtRL1Aw/m/2gAx9Oa8BQAJ).