### PR TITLE
Add Bandwidths() method

### DIFF
--- a/vara/go.mod
+++ b/vara/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/imdario/mergo v0.3.12
-	github.com/la5nta/wl2k-go v0.7.5
+	github.com/la5nta/wl2k-go v0.9.2
 )

--- a/vara/go.sum
+++ b/vara/go.sum
@@ -1,4 +1,4 @@
-github.com/albenik/go-serial/v2 v2.3.0/go.mod h1:JUrQKdczCMB0FlXt2rlJJ8zbfFzmjTIAkLPyyVfr5ho=
+github.com/albenik/go-serial/v2 v2.5.0/go.mod h1:ySdCqoERscw1xluK1n62R8Faoyu+jXKwVHPa1lSSAew=
 github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -9,16 +9,17 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/la5nta/wl2k-go v0.7.5 h1:u8QBMcoTuMxtQ51elQPLB0n7LleItGsIXxCZKxRp3qE=
-github.com/la5nta/wl2k-go v0.7.5/go.mod h1:m/O3yYdsWhPdM1K/nAXqqioWRQGJwgKO7D8pEk6AQeY=
+github.com/la5nta/wl2k-go v0.9.2 h1:PUylTFQk/Sr1dV0ZxPXXwmEXEj3JAEEjyzwenh5+sxo=
+github.com/la5nta/wl2k-go v0.9.2/go.mod h1:0c+/9KyDj7Ra7C/O4rVUYx1CzvdtS65di/93wlI22fo=
 github.com/paulrosania/go-charset v0.0.0-20190326053356-55c9d7a5834c/go.mod h1:YnNlZP7l4MhyGQ4CBRwv6ohZTPrUJJZtEv4ZgADkbs4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
-golang.org/x/sys v0.0.0-20210223212115-eede4237b368/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=

--- a/vara/transport.go
+++ b/vara/transport.go
@@ -61,10 +61,19 @@ func (m *Modem) setBandwidth(url *transport.URL) error {
 	if bw == "" {
 		return nil
 	}
-	if bw != "500" && bw != "2300" && bw != "2750" {
+	if !contains(bandwidths, bw) {
 		return errors.New(fmt.Sprintf("bandwidth %s not supported", bw))
 	}
 	return m.writeCmd(fmt.Sprintf("BW%s", bw))
+}
+
+func contains(c []string, s string) bool {
+	for _, e := range c {
+		if e == s {
+			return true
+		}
+	}
+	return false
 }
 
 // Busy returns true if the channel is not clear.

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -53,10 +53,15 @@ const (
 	disconnected
 )
 
+var bandwidths = []string{"500", "2300", "2750"}
 var debug bool
 
 func init() {
 	debug = os.Getenv("VARA_DEBUG") != ""
+}
+
+func Bandwidths() []string {
+	return bandwidths
 }
 
 // NewModem initializes configuration for a new VARA modem client stub.

--- a/vara/vara_test.go
+++ b/vara/vara_test.go
@@ -19,3 +19,10 @@ func TestInterfaces(t *testing.T) {
 	var _ net.Listener = modem
 	var _ transport.BusyChannelChecker = modem
 }
+
+func TestBandwidths(t *testing.T) {
+	bw := Bandwidths()
+	if !contains(bw, "500") || !contains(bw, "2300") || !contains(bw, "2750") {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This is similar to [ardop](https://github.com/la5nta/wl2k-go/blob/b3b4be1c882d23e62024339b3706f6206d8a38cb/transport/ardop/ardop.go#L102-L114) and can be used to populate a UI selector instead of having the user guess which bandwidths are supported.