### PR TITLE
Use the same init sequence as RMS Express, gracefull disconnect

### DIFF
--- a/vara/transport.go
+++ b/vara/transport.go
@@ -11,7 +11,7 @@ import (
 // Implementations for various wl2k-go/transport interfaces.
 
 func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
-	if url.Scheme != network {
+	if url.Scheme != m.scheme {
 		return nil, transport.ErrUnsupportedScheme
 	}
 
@@ -60,9 +60,18 @@ func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
 		return nil, err
 	}
 
-	// Winlink or radio only? TODO
-	if err := m.writeCmd(fmt.Sprintf("WINLINK SESSION")); err != nil {
-		return nil, err
+	if m.scheme == "varahf" {
+		// VaraHF only - Winlink or P2P?
+		p2p := url.Params.Get("p2p") == "true"
+		if p2p {
+			if err := m.writeCmd(fmt.Sprintf("P2P SESSION")); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := m.writeCmd(fmt.Sprintf("WINLINK SESSION")); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Start connecting

--- a/vara/transport.go
+++ b/vara/transport.go
@@ -30,6 +30,21 @@ func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
 		}
 	}
 
+	// Select public
+	if err := m.writeCmd(fmt.Sprintf("PUBLIC ON")); err != nil {
+		return nil, err
+	}
+
+	// CWID enable
+	if err := m.writeCmd(fmt.Sprintf("CWID ON")); err != nil {
+		return nil, err
+	}
+
+	// Set compression
+	if err := m.writeCmd(fmt.Sprintf("COMPRESSION TEXT")); err != nil {
+		return nil, err
+	}
+
 	// Set MYCALL
 	if err := m.writeCmd(fmt.Sprintf("MYCALL %s", m.myCall)); err != nil {
 		return nil, err
@@ -37,6 +52,16 @@ func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
 
 	// Set bandwidth from the URL
 	if err := m.setBandwidth(url); err != nil {
+		return nil, err
+	}
+
+	// Listen on
+	if err := m.writeCmd(fmt.Sprintf("LISTEN ON")); err != nil {
+		return nil, err
+	}
+
+	// Winlink or radio only? TODO
+	if err := m.writeCmd(fmt.Sprintf("WINLINK SESSION")); err != nil {
 		return nil, err
 	}
 

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -36,6 +36,7 @@ var defaultConfig = ModemConfig{
 }
 
 type Modem struct {
+	scheme        string
 	myCall        string
 	config        ModemConfig
 	cmdConn       *net.TCPConn
@@ -66,12 +67,13 @@ func Bandwidths() []string {
 }
 
 // NewModem initializes configuration for a new VARA modem client stub.
-func NewModem(myCall string, config ModemConfig) (*Modem, error) {
+func NewModem(scheme string, myCall string, config ModemConfig) (*Modem, error) {
 	// Back-fill empty config values with defaults
 	if err := mergo.Merge(&config, defaultConfig); err != nil {
 		return nil, err
 	}
 	return &Modem{
+		scheme:        scheme,
 		myCall:        myCall,
 		config:        config,
 		busy:          false,

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/imdario/mergo"
 	"github.com/la5nta/wl2k-go/transport"
@@ -89,6 +90,9 @@ func (m *Modem) start() error {
 		return err
 	}
 
+	// channel is not busy until Vara tells otherwise
+	m.busy = false
+
 	// Start listening for incoming VARA commands
 	go m.cmdListen()
 	return nil
@@ -96,17 +100,27 @@ func (m *Modem) start() error {
 
 // Close closes the RF and then the TCP connections to the VARA modem. Blocks until finished.
 func (m *Modem) Close() error {
-	// Send ABORT command
-	if m.cmdConn != nil {
-		if err := m.writeCmd("ABORT"); err != nil {
-			return err
-		}
-	}
-
 	// Block until VARA modem acks disconnect
 	if m.lastState == connected {
-		if <-m.connectChange != disconnected {
-			return errors.New("disconnect failed")
+		// Send DISCONNECT command
+		if m.cmdConn != nil {
+			if err := m.writeCmd("DISCONNECT"); err != nil {
+				return err
+			}
+		}
+
+		select {
+		case res := <-m.connectChange:
+			if res != disconnected {
+				log.Println("Disconnect failed, aborting!")
+				if err := m.writeCmd("ABORT"); err != nil {
+					return err
+				}
+			}
+		case <-time.After(time.Second * 60):
+			if err := m.writeCmd("ABORT"); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -117,6 +131,7 @@ func (m *Modem) Close() error {
 
 	// Clear up internal state
 	m.toCall = ""
+	m.busy = false
 	return nil
 }
 
@@ -212,7 +227,7 @@ func (m *Modem) handleCmd(c string) bool {
 			break
 		}
 		if strings.HasPrefix(c, "REGISTERED") {
-			// nothing to do
+			log.Printf("Full speed available, Vara registered to: %s", c[11:])
 			break
 		}
 		log.Printf("got a vara command I wasn't expecting: %v", c)
@@ -239,6 +254,16 @@ func (m *Modem) handleDisconnect() {
 	m.dataConn = disconnectTCP("data", m.dataConn)
 	// Close command port TCP connection
 	m.cmdConn = disconnectTCP("cmd", m.cmdConn)
+}
+
+func (m *Modem) Ping() bool {
+	// TODO
+	return true
+}
+
+func (m *Modem) Version() (string, error) {
+	// TODO
+	return "v1", nil
 }
 
 // If env var VARA_DEBUG exists, log more stuff


### PR DESCRIPTION
I traced the chat between RMS Express and Vara and this is roughly what it does. I also changed ABORT to DISCONNECT with ABORT 10 seconds later.