### PR TITLE
Set LISTEN OFF

### DIFF
--- a/vara/transport.go
+++ b/vara/transport.go
@@ -57,8 +57,8 @@ func (m *Modem) DialURL(url *transport.URL) (net.Conn, error) {
 		return nil, err
 	}
 
-	// Listen on
-	if err := m.writeCmd(fmt.Sprintf("LISTEN ON")); err != nil {
+	// Listen off
+	if err := m.writeCmd(fmt.Sprintf("LISTEN OFF")); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This makes VARA reject inbound connects, which is the only sensible behavior as long as we don't support it.

Resolves #27