### PR TITLE
Add Idle() method exposing the current modem state

### DIFF
--- a/vara/transport.go
+++ b/vara/transport.go
@@ -87,6 +87,7 @@ func (m *Modem) DialURLContext(ctx context.Context, url *transport.URL) (net.Con
 
 	// Start connecting
 	m.toCall = url.Target
+	m.lastState = connecting
 	if err := m.writeCmd(fmt.Sprintf("CONNECT %s %s", m.myCall, m.toCall)); err != nil {
 		return nil, err
 	}

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -58,6 +58,7 @@ type connectedState int
 const (
 	connected connectedState = iota
 	disconnected
+	connecting
 )
 
 var bandwidths = []string{"500", "2300", "2750"}
@@ -106,6 +107,11 @@ func (m *Modem) start() error {
 	return nil
 }
 
+// Idle returns true if the modem is not in a connecting or connected state.
+func (m *Modem) Idle() bool {
+	return m.lastState == disconnected
+}
+
 // Close closes the RF and then the TCP connections to the VARA modem. Blocks until finished.
 func (m *Modem) Close() error {
 	if m.cmdConn == nil {
@@ -125,7 +131,7 @@ func (m *Modem) Close() error {
 	}()
 
 	// Block until VARA modem acks disconnect
-	if m.lastState == connected {
+	if m.lastState != disconnected {
 		// Send DISCONNECT command
 		if m.cmdConn != nil {
 			if err := m.writeCmd("DISCONNECT"); err != nil {


### PR DESCRIPTION
This is needed in order to properly implement a forced/dirty disconnect in Pat.

Ref https://github.com/la5nta/pat/pull/398