### PR TITLE
Fix panic by avoiding use of atomic package

### DIFF
--- a/vara/buffer_count.go
+++ b/vara/buffer_count.go
@@ -1,0 +1,23 @@
+package vara
+
+import "sync"
+
+// bufferCount is a thread-safe int for keeping the buffer count state.
+type bufferCount struct {
+	m sync.RWMutex
+	n int
+}
+
+func newBufferCount() *bufferCount { return &bufferCount{} }
+
+func (m *bufferCount) get() int {
+	m.m.Lock()
+	defer m.m.Unlock()
+	return m.n
+}
+
+func (m *bufferCount) set(n int) {
+	m.m.RLock()
+	m.n = n
+	m.m.RUnlock()
+}

--- a/vara/buffer_count.go
+++ b/vara/buffer_count.go
@@ -4,20 +4,45 @@ import "sync"
 
 // bufferCount is a thread-safe int for keeping the buffer count state.
 type bufferCount struct {
+	ch chan int // Channel for receiving BUFFER updates from the modem.
+
 	m sync.RWMutex
 	n int
 }
 
-func newBufferCount() *bufferCount { return &bufferCount{} }
+func newBufferCount() *bufferCount { return &bufferCount{ch: make(chan int)} }
 
+// get returns the current buffer count.
 func (m *bufferCount) get() int {
 	m.m.RLock()
 	defer m.m.RUnlock()
 	return m.n
 }
 
+// set sets the current buffer count.
 func (m *bufferCount) set(n int) {
 	m.m.Lock()
 	m.n = n
 	m.m.Unlock()
+	select {
+	case m.ch <- n:
+	default:
+	}
+}
+
+// notifyQueued subscribes to BUFFER updates sent from the modem.
+//
+// The returned channel is buffered, allowing the receiver to defer reading
+// from the channel without missing out on the next BUFFER value sent from the
+// modem.
+func (m *bufferCount) notifyQueued() <-chan int {
+	nextUpdate := make(chan int, 1)
+	go func() {
+		defer close(nextUpdate)
+		for n := range m.ch {
+			nextUpdate <- n
+			return
+		}
+	}()
+	return nextUpdate
 }

--- a/vara/buffer_count.go
+++ b/vara/buffer_count.go
@@ -11,13 +11,13 @@ type bufferCount struct {
 func newBufferCount() *bufferCount { return &bufferCount{} }
 
 func (m *bufferCount) get() int {
-	m.m.Lock()
-	defer m.m.Unlock()
+	m.m.RLock()
+	defer m.m.RUnlock()
 	return m.n
 }
 
 func (m *bufferCount) set(n int) {
-	m.m.RLock()
+	m.m.Lock()
 	m.n = n
-	m.m.RUnlock()
+	m.m.Unlock()
 }

--- a/vara/conn.go
+++ b/vara/conn.go
@@ -38,7 +38,7 @@ func (v *varaDataConn) RemoteAddr() net.Addr {
 }
 
 func (v *varaDataConn) Write(b []byte) (int, error) {
-	queued := v.modem.notifyQueued()
+	queued := v.modem.bufferCount.notifyQueued()
 	n, err := v.TCPConn.Write(b)
 	// Block until the modem confirms that data has been added to the
 	// transmit buffer queue. This is needed to ensure TxBufferLen are
@@ -56,4 +56,4 @@ func (v *varaDataConn) Write(b []byte) (int, error) {
 
 // TxBufferLen implements the transport.TxBuffer interface.
 // It returns the current number of bytes in the TX buffer queue or in transit to the modem.
-func (v *varaDataConn) TxBufferLen() int { return v.modem.getBufferCount() }
+func (v *varaDataConn) TxBufferLen() int { return v.modem.bufferCount.get() }

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -48,8 +48,7 @@ type Modem struct {
 	lastState     connectedState
 	rig           transport.PTTController
 
-	bufferUpdates chan int // Signals an incoming BUFFER
-	bufferCount   *bufferCount
+	bufferCount *bufferCount
 }
 
 type connectedState int
@@ -84,7 +83,6 @@ func NewModem(scheme string, myCall string, config ModemConfig) (*Modem, error) 
 		busy:          false,
 		connectChange: make(chan connectedState, 1),
 		lastState:     disconnected,
-		bufferUpdates: make(chan int),
 		bufferCount:   newBufferCount(),
 	}, nil
 }
@@ -171,26 +169,6 @@ func (m *Modem) Close() error {
 	m.toCall = ""
 	m.busy = false
 	return nil
-}
-
-func (m *Modem) getBufferCount() int  { return m.bufferCount.get() }
-func (m *Modem) setBufferCount(n int) { m.bufferCount.set(n) }
-
-// notifyQueued subscribes to BUFFER updates sent from the modem.
-//
-// The returned channel is buffered, allowing the receiver to defer reading
-// from the channel without missing out on the next BUFFER value sent from the
-// modem.
-func (m *Modem) notifyQueued() <-chan int {
-	queued := make(chan int, 1)
-	go func() {
-		defer close(queued)
-		for n := range m.bufferUpdates {
-			queued <- n
-			return
-		}
-	}()
-	return queued
 }
 
 func (m *Modem) connectTCP(name string, port int) (*net.TCPConn, error) {
@@ -291,11 +269,7 @@ func (m *Modem) handleCmd(c string) bool {
 				// not a valid int. nothing to do.
 				break
 			}
-			m.setBufferCount(n)
-			select {
-			case m.bufferUpdates <- n:
-			default:
-			}
+			m.bufferCount.set(n)
 			break
 		}
 		if strings.HasPrefix(c, "REGISTERED") {


### PR DESCRIPTION
Turns out the atomic package have some caveats when building for 32-bit architectures. The easiest solution is to simply use a mutex instead.

Ref issue la5nta/pat#402