### PR TITLE
Modified the algorithm to estimate the comm buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 A VARA transporter for the Pat Winlink Open Source project.
 
 ## Status:
+** mars 14 2025** : vtbd new algorithm to estimate the comm buffer size
+
 **JUN 18, 2025**: v1.2.0 released. Adds [callback-based busy channel handling](https://github.com/n8jja/Pat-Vara/pull/44)
 
 **OCT 19, 2023**: v1.1.4 released with minor bug fixes and improvements.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hb9tob/Pat-Vara
+module github.com/n8jja/Pat-Vara
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/n8jja/Pat-Vara
+module github.com/hb9tob/Pat-Vara
 
 go 1.16
 

--- a/vara/conn.go
+++ b/vara/conn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 )
@@ -85,6 +86,8 @@ func (v *conn) Close() error {
 	var err error
 	v.closeOnce.Do(func() {
 		debugPrint("Closing connection...")
+		// Reset buffer size for the next connexion
+		bufferMaxSize = -1
 		if v.Modem.closed {
 			err = ErrModemClosed
 			return
@@ -110,7 +113,6 @@ func (v *conn) Close() error {
 		if dur := time.Since(v.lastWrite); dur < 2*time.Second {
 			<-time.After(2*time.Second - dur)
 		}
-
 		v.writeCmd("DISCONNECT")
 		select {
 		case _, ok := <-connectChange:
@@ -181,8 +183,10 @@ func (v *conn) Read(b []byte) (n int, err error) {
 	}
 }
 
+var bufferMaxSize = -1
+
 func (v *conn) Write(b []byte) (int, error) {
-	cmds, cancel := v.cmds.Subscribe("DISCONNECTED", "BUFFER")
+	cmds, cancel := v.cmds.Subscribe("DISCONNECTED", "BUFFER", "BITRATE", "SN")
 	defer cancel()
 	if v.connectedState != connected {
 		return 0, io.EOF
@@ -196,13 +200,44 @@ func (v *conn) Write(b []byte) (int, error) {
 	// small, we end up causing unnecessary IDLE time. Too large and we end up with non-blocking writes and
 	// a very large TX buffer causing Close() to block for a very long time. This magic number seem to work
 	// well enough for both VARA FM and VARA HF.
-	const magicNumber = 100
+
+	// THE MAGIC NUMBER DID NOT WORK FOR ME
+	// When the link quality is high enough the vara modem estimate the air speed based on the SNR of the previous
+	// transmission and the data in it's buffer.
+	// If the amount of data is lower than a full air frame at the maximum possible speed the Vara modem will do two things :
+	// - It will adapt the max air speed to transmit the content of the content of the buffer
+	// - It will also suppose that there is no more data to transmit for the moment and send a break signal to it's peer
+	//
+	// Then a full link estimation is done for the next packed
+	// This end to a very sub-optimum speed
+	//
+	// Due to the long interleaving FEC used by the modem the buffer must be filled with at least enough data for the next
+	// air frame, as the modem did not sen BUFFER signal during the TX and need to have enough data to calculate
+	// the frame with the FEC prior to start TX
+	// This is an attemp to overcome this issue using the last TX speed and the SNR to estimate the air speed
+	// before the start the playload transmission and size the buffer accordingly
+	// The buffer is sized to store 2 air frames around 12 seconds
+
+	const magicNumber = 7
+	const airTime = 12
+
+	// start with magic number as first estimation
+	if bufferMaxSize == -1 {
+		bufferMaxSize = magicNumber * len(b)
+	}
+
+	// Adapt the buufer size to store 2 frames at max speed
+	if (v.maxBitRate*airTime)/8 > bufferMaxSize {
+		bufferMaxSize = (v.maxBitRate * airTime) / 8
+		debugPrint("Buffer size adapted for high speed to %d", bufferMaxSize)
+	}
 
 	bufferTimeout := time.NewTimer(time.Minute)
 	defer bufferTimeout.Stop()
 	bufferCount := v.bufferCount.get()
-	for bufferCount >= magicNumber*len(b) && !v.closing {
-		debugPrint("write: buffer full (%d >= %d)", bufferCount, magicNumber*len(b))
+	for bufferCount >= bufferMaxSize && !v.closing {
+
+		debugPrint("write: buffer full (%d >= %d)", bufferCount, bufferMaxSize)
 		select {
 		case cmd, ok := <-cmds:
 			switch {
@@ -211,6 +246,20 @@ func (v *conn) Write(b []byte) (int, error) {
 			case cmd == "DISCONNECTED":
 				debugPrint("write: state changed while waiting for buffer space")
 				return 0, io.EOF
+			case strings.HasPrefix(cmd, "BITRATE"):
+				// We have a new bit rate, resize the buffer if needed
+				debugPrint("BITRATE  %s", cmd)
+				if (v.maxBitRate*airTime)/8 > bufferMaxSize {
+					bufferMaxSize = (v.maxBitRate * airTime) / 8
+					debugPrint("Buffer size adapted for high speed to %d", bufferMaxSize)
+				}
+			case strings.HasPrefix(cmd, "SN"):
+				// We have a new SN, resize the buffer if needed
+				debugPrint("SN  %s", cmd)
+				if (v.maxBitRate*airTime)/8 > bufferMaxSize {
+					bufferMaxSize = (v.maxBitRate * airTime) / 8
+					debugPrint("Buffer size adapted for high speed to %d", bufferMaxSize)
+				}
 			default:
 				bufferCount = parseBuffer(cmd)
 				if !bufferTimeout.Stop() {

--- a/vara/conn.go
+++ b/vara/conn.go
@@ -196,7 +196,7 @@ func (v *conn) Write(b []byte) (int, error) {
 	// small, we end up causing unnecessary IDLE time. Too large and we end up with non-blocking writes and
 	// a very large TX buffer causing Close() to block for a very long time. This magic number seem to work
 	// well enough for both VARA FM and VARA HF.
-	const magicNumber = 25
+	const magicNumber = 100
 
 	bufferTimeout := time.NewTimer(time.Minute)
 	defer bufferTimeout.Stop()

--- a/vara/conn.go
+++ b/vara/conn.go
@@ -196,7 +196,7 @@ func (v *conn) Write(b []byte) (int, error) {
 	// small, we end up causing unnecessary IDLE time. Too large and we end up with non-blocking writes and
 	// a very large TX buffer causing Close() to block for a very long time. This magic number seem to work
 	// well enough for both VARA FM and VARA HF.
-	const magicNumber = 7
+	const magicNumber = 25
 
 	bufferTimeout := time.NewTimer(time.Minute)
 	defer bufferTimeout.Stop()

--- a/vara/conn.go
+++ b/vara/conn.go
@@ -205,17 +205,17 @@ func (v *conn) Write(b []byte) (int, error) {
 	// When the link quality is high enough the vara modem estimate the air speed based on the SNR of the previous
 	// transmission and the data in it's buffer.
 	// If the amount of data is lower than a full air frame at the maximum possible speed the Vara modem will do two things :
-	// - It will adapt the max air speed to transmit the content of the content of the buffer
+	// - It will adapt the max air speed to transmit the content of  the buffer
 	// - It will also suppose that there is no more data to transmit for the moment and send a break signal to it's peer
 	//
-	// Then a full link estimation is done for the next packed
+	// Then a full link estimation is done for the next frame
 	// This end to a very sub-optimum speed
 	//
 	// Due to the long interleaving FEC used by the modem the buffer must be filled with at least enough data for the next
-	// air frame, as the modem did not sen BUFFER signal during the TX and need to have enough data to calculate
+	// air frame, as the modem did not send BUFFER signal during the TX and need to have enough data to calculate
 	// the frame with the FEC prior to start TX
 	// This is an attemp to overcome this issue using the last TX speed and the SNR to estimate the air speed
-	// before the start the playload transmission and size the buffer accordingly
+	// before the start of the playload transmission and size the buffer accordingly
 	// The buffer is sized to store 2 air frames around 12 seconds
 
 	const magicNumber = 7

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -353,7 +353,7 @@ func (m *Modem) handleCmd(c string) {
 		if strings.HasPrefix(c, "VERSION") {
 			break
 		}
-		debugPrint("got a vara command I wasn't expecting2: %q", c)
+		debugPrint("got a vara command I wasn't expecting: %q", c)
 	}
 }
 

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -50,10 +51,15 @@ type Modem struct {
 	inboundConns   chan *conn
 	connectedState connectedState
 	rig            transport.PTTController
-
-	bufferCount *bufferCount
-	closeOnce   sync.Once
-	closed      bool
+	varaFM         bool
+	varaFMWIDE     bool
+	vara2750       bool
+	currentBitrate int
+	maxBitRate     int
+	SN             float64
+	bufferCount    *bufferCount
+	closeOnce      sync.Once
+	closed         bool
 }
 
 type connectedState int
@@ -304,17 +310,33 @@ func (m *Modem) handleCmd(c string) {
 		}
 		if strings.HasPrefix(c, "CONNECTED ") {
 			m.handleConnected(c)
+			if strings.Contains(c, "WIDE") {
+				m.varaFMWIDE = true
+				EstimateBitRate(m)
+			}
+			if strings.Contains(c, "2750") {
+				m.vara2750 = true
+				EstimateBitRate(m)
+			}
+			if strings.Contains(c, "2300") {
+				m.vara2750 = true
+				EstimateBitRate(m)
+			}
 			break
 		}
 
 		if strings.HasPrefix(c, "BITRATE") {
-			debugPrint("got BITRATE%q", c)
+			debugPrint("got BITRATE %q", c)
+			m.currentBitrate = parseBitrate(c)
+			EstimateBitRate(m)
 			break
 		}
-
-	case "BITRATE":
-		debugPrint("got BITRATE")
-		// nothing to do
+		if strings.HasPrefix(c, "SN ") {
+			debugPrint("got SN %q", c)
+			m.SN = parseSN(c)
+			EstimateBitRate(m)
+			break
+		}
 
 		if strings.HasPrefix(c, "REGISTERED") {
 			parts := strings.Split(c, " ")
@@ -323,6 +345,11 @@ func (m *Modem) handleCmd(c string) {
 			}
 			break
 		}
+		if strings.HasPrefix(c, "VERSION VARA FM") {
+			m.varaFM = true
+			break
+		}
+
 		if strings.HasPrefix(c, "VERSION") {
 			break
 		}
@@ -340,6 +367,13 @@ func (m *Modem) handleDisconnected() {
 	m.connectedState = disconnected
 	m.bufferCount.reset()       // reset buffer count in case we had outstanding frames
 	m.setBandwidth(m.bandwidth) // reset bandwidth to default in case it was changed
+	// Reset the vars for the chanell speed estimation
+	m.varaFM = false
+	m.varaFMWIDE = false
+	m.vara2750 = false
+	m.currentBitrate = 0
+	m.maxBitRate = 0
+	m.SN = 0
 }
 
 func (m *Modem) handleConnected(cmd string) {
@@ -378,4 +412,112 @@ func (m *Modem) Version() (string, error) {
 		return "", errors.New("VERSION not implemented")
 	}
 	return strings.TrimPrefix(str, "VERSION "), nil
+}
+
+func parseBitrate(s string) int {
+	parts := strings.Split(s, " ")
+	if len(parts) < 5 {
+		debugPrint("BITRATE not complete  %q", s)
+		return -1
+	}
+	if parts[5] == "TX" {
+		n, _ := strconv.Atoi(parts[3])
+		return n
+	}
+	return -1
+}
+
+func parseSN(s string) float64 {
+	rs := strings.Replace(s, "SN ", "", -1)
+	n, _ := strconv.ParseFloat(rs, 64)
+	return n
+
+}
+
+func EstimateBitRate(m *Modem) int {
+	// Take the maximum recieved bitrate
+	ebr := m.currentBitrate
+	if ebr > m.maxBitRate {
+		m.maxBitRate = ebr
+		debugPrint("Max bit rate set to %d by BITRATE", m.currentBitrate)
+	}
+
+	// Try to estimate the max bitrate based on the mode and the SN
+	if m.varaFM {
+		if m.varaFMWIDE {
+			debugPrint("Estimate SN vara FM Wide %f", m.SN)
+			ebr = 1098
+			if m.SN > 5 {
+				ebr = 4040
+			}
+			if m.SN > 10 {
+				ebr = 5387
+			}
+			if m.SN > 20 {
+				ebr = 16832
+			}
+		} else {
+			debugPrint("Estimate SN vara FM Narrow %f", m.SN)
+			ebr = 1098
+			if m.SN > 5 {
+				ebr = 4040
+			}
+			if m.SN > 10 {
+				ebr = 7185
+			}
+			if m.SN > 20 {
+				ebr = 10585
+			}
+		}
+	} else {
+		if m.vara2750 {
+			debugPrint("Estimate SN vara HF 2750 %f", m.SN)
+			ebr = 150
+			if m.SN > 5 {
+				ebr = 300
+			}
+			if m.SN > 10 {
+				ebr = 600
+			}
+			if m.SN > 15 {
+				ebr = 1600
+			}
+			if m.SN > 20 {
+				ebr = 3333
+			}
+			if m.SN > 25 {
+				ebr = 4933
+			}
+			if m.SN > 30 {
+				ebr = 6000
+			}
+		} else {
+			debugPrint("Estimate SN vara HF 500 %f", m.SN)
+			ebr = 50
+			if m.SN > 5 {
+				ebr = 133
+			}
+			if m.SN > 10 {
+				ebr = 466
+			}
+			if m.SN > 15 {
+				ebr = 800
+			}
+			if m.SN > 20 {
+				ebr = 1066
+			}
+			if m.SN > 25 {
+				ebr = 1333
+			}
+			if m.SN > 30 {
+				ebr = 1543
+			}
+		}
+	}
+
+	if ebr > m.maxBitRate {
+		m.maxBitRate = ebr
+		debugPrint("Max bit rate set to %d by SN", ebr)
+	}
+	return m.maxBitRate
 }

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -286,9 +286,7 @@ func (m *Modem) handleCmd(c string) {
 		// nothing to do
 	case "PENDING":
 		// nothing to do
-	case "BITRATE":
-		debugPrint("got BITRATE")
-		// nothing to do
+
 	case "CANCELPENDING":
 		// nothing to do
 	case "LINK UNREGISTERED", "LINK REGISTERED":
@@ -308,6 +306,16 @@ func (m *Modem) handleCmd(c string) {
 			m.handleConnected(c)
 			break
 		}
+
+		if strings.HasPrefix(c, "BITRATE") {
+			debugPrint("got BITRATE%q", c)
+			break
+		}
+
+	case "BITRATE":
+		debugPrint("got BITRATE")
+		// nothing to do
+
 		if strings.HasPrefix(c, "REGISTERED") {
 			parts := strings.Split(c, " ")
 			if len(parts) > 1 {

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -326,7 +326,7 @@ func (m *Modem) handleCmd(c string) {
 		if strings.HasPrefix(c, "VERSION") {
 			break
 		}
-		debugPrint("got a vara command I wasn't expecting: %q", c)
+		debugPrint("got a vara command I wasn't expecting2: %q", c)
 	}
 }
 

--- a/vara/vara.go
+++ b/vara/vara.go
@@ -286,6 +286,9 @@ func (m *Modem) handleCmd(c string) {
 		// nothing to do
 	case "PENDING":
 		// nothing to do
+	case "BITRATE":
+		debugPrint("got BITRATE")
+		// nothing to do
 	case "CANCELPENDING":
 		// nothing to do
 	case "LINK UNREGISTERED", "LINK REGISTERED":


### PR DESCRIPTION
// THE MAGIC NUMBER DID NOT WORK FOR ME
	// When the link quality is high enough the vara modem estimate the air speed based on the SNR of the previous
	// transmission and the data in it's buffer.
	// If the amount of data is lower than a full air frame at the maximum possible speed the Vara modem will do two         
        // things :
	// - It will adapt the max air speed to transmit the content of  the buffer
	// - It will also suppose that there is no more data to transmit for the moment and send a break signal to it's peer
	//
	// Then a full link estimation is done for the next frame
	// This end to a very sub-optimum speed
	//
	// Due to the long interleaving FEC used by the modem the buffer must be filled with at least enough data for the next
	// air frame, as the modem did not send BUFFER signal during the TX and need to have enough data to calculate
	// the frame with the FEC prior to start TX
	// This is an attempt to overcome this issue using the last TX speed and the SNR to estimate the air speed
	// before the start of the playload transmission and size the buffer accordingly
	// The buffer is sized to store 2 air frames around 12 seconds
